### PR TITLE
census: language ratio and list of extensions

### DIFF
--- a/census.py
+++ b/census.py
@@ -18,6 +18,7 @@ class Statistics(object):
     """
     Takes care of all types of statistical analysis
     """
+
     def __init__(self,
                  root_dir,
                  parse_step_len: int = 20000,
@@ -135,6 +136,7 @@ class Statistics(object):
             percents = self.__get_progress_in_percents(0, current, files_count)
             print(f'{current}/{files_count} files checked ({percents}%)',
                   end='\r')
+
         self.language_stats.collection_creation_end()
         return self
 
@@ -235,6 +237,32 @@ class TagsCollection(TimedCollectionBase):
 class LanguageStatsCollection(TimedCollectionBase):
     def __init__(self):
         super().__init__('LanguageStats')
+
+    def collection_creation_end(self):
+        total_lines = 0
+        total_code = 0
+        total_code_comments = 0
+        for language in self.collection:
+            lang = self.collection[language]
+            total_lines += lang.code_lines + lang.comment_lines + lang.empty_lines
+            total_code += lang.code_lines
+            total_code_comments += lang.code_lines + lang.comment_lines
+
+        for language in self.collection:
+            lang = self.collection[language]
+            lang.ratio_code = self.__get_ratio_in_percents(
+                lang.code_lines, total_code)
+            lang.ratio_code_comments = self.__get_ratio_in_percents(
+                lang.code_lines + lang.comment_lines, total_code_comments)
+            lang.ratio_total_lines = self.__get_ratio_in_percents(
+                lang.code_lines + lang.comment_lines + lang.empty_lines, total_lines)
+        super().collection_creation_end()
+
+    @staticmethod
+    def __get_ratio_in_percents(current, total, precision=3):
+        ratio = current / total
+        percents = round(ratio * 100, precision)
+        return min(percents, 100)
 
 
 class CodeFileInfoCollection(TimedCollectionBase):

--- a/loc/line_counter.py
+++ b/loc/line_counter.py
@@ -119,15 +119,13 @@ class LineCounter:
     def count(self) -> CodeFileInfo:
         _, ext = os.path.splitext(self.code_file_path)
         ext = ext.lower()
-        file_type = "other"
         comments = []
         description = "Unknown"
         language = "Unknown"
         if ext in known_types:
-            file_type = ext
-            comments = known_types[file_type]["comments"]
-            description = known_types[file_type]["description"]
-            language = known_types[file_type]["language"]
+            comments = known_types[ext]["comments"]
+            description = known_types[ext]["description"]
+            language = known_types[ext]["language"]
         code_lines = 0
         comment_lines = 0
         empty_lines = 0
@@ -173,7 +171,7 @@ class LineCounter:
         else:
             return CodeFileInfo(self.code_file_path,
                                 language,
-                                file_type,
+                                ext,
                                 comment_lines,
                                 code_lines,
                                 empty_lines,

--- a/models/language_stats.py
+++ b/models/language_stats.py
@@ -13,6 +13,10 @@ class LanguageStats(TableInterface):
         self.comment_lines: int = 0
         self.empty_lines: int = 0
         self.files_count: int = 0
+        self.extensions_found: list = []
+        self.ratio_code: float = 0
+        self.ratio_code_comments: float = 0
+        self.ratio_total_lines: float = 0
 
     def add_code_file_info(self, code_file_info: CodeFileInfo):
         """
@@ -35,6 +39,8 @@ class LanguageStats(TableInterface):
         self.code_lines += code_file_info.code_lines
         self.comment_lines += code_file_info.comment_lines
         self.empty_lines += code_file_info.empty_lines
+        if code_file_info.file_ext not in self.extensions_found:
+            self.extensions_found.append(code_file_info.file_ext)
         self.files_count += 1
 
     def get_table_row(self) -> []:
@@ -42,11 +48,19 @@ class LanguageStats(TableInterface):
                 self.code_lines,
                 self.comment_lines,
                 self.empty_lines,
-                self.files_count]
+                self.files_count,
+                self.ratio_code,
+                self.ratio_code_comments,
+                self.ratio_total_lines,
+                self.extensions_found]
 
     def get_table_headers(self) -> []:
         return ["Language",
                 "Code lines",
                 "Comment lines",
                 "Empty lines",
-                "Files count"]
+                "Files count",
+                "code%",
+                "code+comments%",
+                "total%",
+                "Extensions found"]


### PR DESCRIPTION
1. Language ratio - refers to the proportion of each language compared
to total amount of lines, represented in percents: by code, by
code+comments, and by file-lines.

Closes #28

2. List of extensions - some languages can have several extensions
(like: c - .c, .h), also sometimes it is useful to have list of
"unknown" extensions to expand the configuration if possible. The list
of extensions come with LanguageStats objects and printed in UI.

Closes #76