### PR TITLE
Separate plain text and source lines counting

### DIFF
--- a/census.py
+++ b/census.py
@@ -250,7 +250,10 @@ class LanguageStatsCollection(TimedCollectionBase):
         total_code_comments = 0
         for language in self.collection:
             lang = self.collection[language]
-            total_lines += lang.code_lines + lang.comment_lines + lang.empty_lines
+            total_lines += lang.code_lines + \
+                           lang.comment_lines + \
+                           lang.empty_lines + \
+                           lang.text_lines
             total_code += lang.code_lines
             total_code_comments += lang.code_lines + lang.comment_lines
 
@@ -261,7 +264,8 @@ class LanguageStatsCollection(TimedCollectionBase):
             lang.ratio_code_comments = self.__get_ratio_in_percents(
                 lang.code_lines + lang.comment_lines, total_code_comments)
             lang.ratio_total_lines = self.__get_ratio_in_percents(
-                lang.code_lines + lang.comment_lines + lang.empty_lines, total_lines)
+                lang.code_lines + lang.comment_lines + lang.empty_lines +
+                lang.text_lines, total_lines)
         super().collection_creation_end()
 
     @staticmethod

--- a/loc/known_types.json
+++ b/loc/known_types.json
@@ -2,106 +2,127 @@
     ".c": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "C source",
+        "is_source_code": true,
         "language": "C"
     },
     ".h": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "C header",
+        "is_source_code": true,
         "language": "C"
     },
     ".cpp": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "C++ source",
+        "is_source_code": true,
         "language": "C++"
     },
     ".hpp": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "C++ header",
+        "is_source_code": true,
         "language": "C++"
     },
     ".cs": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "C# source",
+        "is_source_code": true,
         "language": "C#"
     },
     ".java": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "Java source",
+        "is_source_code": true,
         "language": "Java"
     },
     ".go": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "Golang source",
+        "is_source_code": true,
         "language": "Go"
     },
     ".s": {
         "comments": [["#", "\n"], ["//", "\n"], ["/*", "*/"]],
         "description": "Assembly source",
+        "is_source_code": true,
         "language": "Assembly"
     },
     ".asm": {
         "comments": [[";", "\n"]],
         "description": "Assembly source",
+        "is_source_code": true,
         "language": "Assembly"
     },
     ".py": {
         "comments": [["#", "\n"]],
         "description": "Python source",
+        "is_source_code": true,
         "language": "Python"
     },
     ".yml": {
         "comments": [["#", "\n"]],
         "description": "Yaml source",
+        "is_source_code": true,
         "language": "Yaml"
     },
     ".yaml": {
         "comments": [["#", "\n"]],
         "description": "Yaml source",
+        "is_source_code": true,
         "language": "Yaml"
     },
     ".md": {
         "comments": [],
         "description": "Markdown file",
+        "is_source_code": false,
         "language": "Markdown"
     },
     ".json": {
         "comments": [],
         "description": "Json file",
+        "is_source_code": false,
         "language": "JSON"
     },
     ".js": {
         "comments": [["//", "\n"], ["/*", "*/"]],
         "description": "Javascript source",
+        "is_source_code": false,
         "language": "Javascript"
     },
     ".txt": {
         "comments": [],
         "description": "Text file",
+        "is_source_code": false,
         "language": "Plain text"
     },
     ".rst": {
         "comments": [],
         "description": "Restructured text file",
+        "is_source_code": false,
         "language": "Formatted text"
     },
     ".sh": {
         "comments": [["#", "\n"]],
         "description": "Shell script file",
+        "is_source_code": true,
         "language": "Shell script"
     },
     ".bb": {
         "comments": [["#", "\n"]],
         "description": "Bitbake file",
+        "is_source_code": true,
         "language": "Bitbake"
     },
     ".bbclass": {
         "comments": [["#", "\n"]],
         "description": "Bitbake class",
+        "is_source_code": true,
         "language": "Bitbake"
     },
     ".bbappend": {
         "comments": [["#", "\n"]],
         "description": "Bitbake append file",
+        "is_source_code": true,
         "language": "Bitbake"
     }
 }

--- a/loc/line_counter.py
+++ b/loc/line_counter.py
@@ -122,10 +122,12 @@ class LineCounter:
         comments = []
         description = "Unknown"
         language = "Unknown"
+        is_source_code = False
         if ext in known_types:
             comments = known_types[ext]["comments"]
             description = known_types[ext]["description"]
             language = known_types[ext]["language"]
+            is_source_code = known_types[ext]["is_source_code"]
         code_lines = 0
         comment_lines = 0
         empty_lines = 0
@@ -175,7 +177,8 @@ class LineCounter:
                                 comment_lines,
                                 code_lines,
                                 empty_lines,
-                                description)
+                                description,
+                                is_source_code)
         finally:
             for error in self.errors:
                 print(f"ERROR: {error}")

--- a/models/code_file_info.py
+++ b/models/code_file_info.py
@@ -12,7 +12,8 @@ class CodeFileInfo(TableInterface):
                  comment_lines: int,
                  code_lines: int,
                  empty_lines: int,
-                 description: str):
+                 description: str,
+                 is_source_code: bool):
         """
         Initializes a new instance of CodeFileInfo
         @param file_path: path to the file
@@ -23,6 +24,7 @@ class CodeFileInfo(TableInterface):
         @param comment_lines: count of the comment lines in the file
         @param empty_lines: count of the empty lines in the file
         @param description: file description according to its extension
+        @param is_source_code: whether file is a source code or a text
         """
         self.file_path: str = file_path
         self.language: str = language
@@ -31,6 +33,7 @@ class CodeFileInfo(TableInterface):
         self.comment_lines: int = comment_lines
         self.empty_lines: int = empty_lines
         self.description: str = description
+        self.is_source_code: bool = is_source_code
 
     def get_table_row(self) -> []:
         return [self.file_path,

--- a/models/language_stats.py
+++ b/models/language_stats.py
@@ -11,6 +11,7 @@ class LanguageStats(TableInterface):
         self.language: str = language
         self.code_lines: int = 0
         self.comment_lines: int = 0
+        self.text_lines: int = 0
         self.empty_lines: int = 0
         self.files_count: int = 0
         self.extensions_found: list = []
@@ -36,7 +37,10 @@ class LanguageStats(TableInterface):
                   f'destination language "{self.language}"')
             return
         self.code_file_info_lst.append(code_file_info)
-        self.code_lines += code_file_info.code_lines
+        if code_file_info.is_source_code:
+            self.code_lines += code_file_info.code_lines
+        else:
+            self.text_lines += code_file_info.code_lines
         self.comment_lines += code_file_info.comment_lines
         self.empty_lines += code_file_info.empty_lines
         if code_file_info.file_ext not in self.extensions_found:
@@ -48,6 +52,7 @@ class LanguageStats(TableInterface):
                 self.code_lines,
                 self.comment_lines,
                 self.empty_lines,
+                self.text_lines,
                 self.files_count,
                 self.ratio_code,
                 self.ratio_code_comments,
@@ -59,6 +64,7 @@ class LanguageStats(TableInterface):
                 "Code lines",
                 "Comment lines",
                 "Empty lines",
+                "Text lines",
                 "Files count",
                 "code%",
                 "code+comments%",


### PR DESCRIPTION
Plain text lines were counted together with source lines, it was
affecting the final result.
This update delivers following:
 - if the extension is a source code or not is configurable and
set as a parameter is_source_code in known_types.json file.
 - text lines and source code lines are counted separately
 - line count percentage between different languages is present in
 final results. Note: this count omits empty lines, hence, if file
 contains 5 lines among which 3 are code lines, 1 comment and 2 are
 empty, it will count 4 lines.
 - percentage ratio between code and rest of the files, including the
 plain text + unknown files are still kept in total% column.

 Closes #80