### PR TITLE
Add multiline comment support for python

### DIFF
--- a/config/known_types.json
+++ b/config/known_types.json
@@ -54,7 +54,7 @@
         "language": "Assembly"
     },
     ".py": {
-        "comments": [["#", "\n"]],
+        "comments": [["#", "\n"], ["\"\"\"", "\"\"\"\n"], ["'''", "'''\n"]],
         "description": "Python source",
         "is_source_code": true,
         "language": "Python"

--- a/loc/line_counter.py
+++ b/loc/line_counter.py
@@ -149,17 +149,26 @@ class LineCounter:
                     empty_lines += 1
                     continue
                 for comment in comments:
-                    if (len(comment)) < 2:
-                        msg = f'known_types.json->comments must be array of array [["start", "end"]] or empty [].' \
+                    if len(comment) < 2:
+                        msg = f'known_types.json->comments must be array of ' \
+                              f'array [["start", "end"]] or empty [].' \
                               f' Check {ext}'
                         print(msg)
                         continue
                     comment_start = comment[0]
                     if line.startswith(comment_start):
+                        not_code_line = True
                         comment_end = comment[1]
                         comment_lines += 1
-                        comment_end_found = comment_end in line
-                        not_code_line = True
+                        # Calculate minimum expected length of the line to
+                        # register the comment end
+                        min_len = len(comment_start) + len(comment_end)
+                        comment_end_found = (
+                                comment_end in line
+                                and
+                                len(line) >= min_len
+                        )
+
                 if not_code_line:
                     not_code_line = False
                     continue


### PR DESCRIPTION
Python multiline comments are different from other languages that we
have in known types so far. Its comment start and end looks similar,
also this kind of comment can be representing the string in the file
if it is assigned to the variable. This check we don't have so far and
we will discover multiline comments if they are starting the line (the
whitespace characters are allowed) but if they are assigned to the
variable for example:
MSG = \
 """ THIS IS THE MESSAGE """

the following line with """ enclosings will be counted as a comment.
Solution for this kind of miscountings we currently don't have
implemented but is considered to add in the future.

Closes #101