### PR TITLE
Lines of codes in files and folders

### DIFF
--- a/census.py
+++ b/census.py
@@ -21,6 +21,8 @@ class Statistics(object):
 
     def __init__(self,
                  root_dir,
+                 files=None,
+                 directories=None,
                  parse_step_len: int = 20000,
                  count_continued_lines: bool = False,
                  runner=CmdRunner):
@@ -36,6 +38,9 @@ class Statistics(object):
         self.last_commit_date = self.runner.run(Cmd.LAST_COMMIT_DATE).stdout
         self.parse_step_len: int = int(parse_step_len)
         self.root_dir: str = root_dir
+        self.files = files
+        self.directories = directories
+
         self.count_continued_lines = count_continued_lines
         self.errors: list = []
         self.authors_per_month = {}
@@ -140,15 +145,19 @@ class Statistics(object):
         return self
 
     def parse_contribution_in_current_code(self):
-
         return self
 
     def count_lines(self):
         self.language_stats.collection_creation_start()
-        files_to_analyze = line_counter.get_file_names(self.root_dir)
-        files_count = len(files_to_analyze)
+
+        if self.files or self.directories:
+            for stat_dir in self.directories:
+                self.files.extend(line_counter.get_file_names(stat_dir))
+        else:
+            self.files = line_counter.get_file_names(self.root_dir)
+        files_count = len(self.files)
         current = 0
-        for file in files_to_analyze:
+        for file in self.files:
             current += 1
             cf_analyzer = LineCounter(file)
             cfi = cf_analyzer.count(self.count_continued_lines)

--- a/loc/line_counter.py
+++ b/loc/line_counter.py
@@ -60,7 +60,7 @@ def ignored_files_clear():
 def ignored_directories_extend(directories):
     """
     Extend ignored directories list
-    
+
     Parameters
     ----------
     directories : dict
@@ -72,7 +72,7 @@ def ignored_directories_extend(directories):
 def ignored_extensions_extend(extensions):
     """
     Extend ignored extensions list
-    
+
     Parameters
     ----------
     extensions : list
@@ -84,7 +84,7 @@ def ignored_extensions_extend(extensions):
 def ignored_subdirectories_extend(subdirs):
     """
     Extend ignored_subdirectories list
-    
+
     Parameters
     ----------
     subdirs : dict
@@ -108,7 +108,7 @@ def ignored_files_extend(files):
 class LineCounter:
     """
     Analyze code and count lines
-    
+
     Parameters
     ----------
     code_file_path : str
@@ -203,11 +203,11 @@ def get_file_names(root_dir: str):
     """
     Get all files under the root_dir except files that are placed in the
     ignored directories or have ignored extensions
-    
+
     Parameters
     ----------
     root_dir : str
-    
+
     Returns
     -------
     list of str

--- a/run.py
+++ b/run.py
@@ -43,9 +43,14 @@ def prepare_results(root_dir: str, start_time: datetime) -> str:
 
 
 def prepare_for_statistics(root_dir,
+                           files,
+                           directories,
                            commits_per_step,
                            count_continued_lines) -> Statistics:
-    statistics = Statistics(root_dir, commits_per_step,
+    statistics = Statistics(root_dir,
+                            files,
+                            directories,
+                            commits_per_step,
                             count_continued_lines=count_continued_lines)
     request_map = {
         'authors': statistics.parse_authors,
@@ -64,6 +69,18 @@ if __name__ == "__main__":
                         metavar='',
                         help='Path to project root directory',
                         default="./")
+    parser.add_argument('-fl',
+                        '--files',
+                        metavar='',
+                        help='File paths to count lines in',
+                        default=[],
+                        nargs="+")
+    parser.add_argument('-dirs',
+                        '--directories',
+                        metavar='',
+                        help='Directories to count lines in',
+                        default=[],
+                        nargs="+")
     parser.add_argument('-id',
                         '--igndir',
                         metavar='',
@@ -115,6 +132,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     main_script_dir = sys.path[0]
     args.projdir = os.path.abspath(args.projdir)
+    args.files = [os.path.abspath(p) for p in args.files]
+    args.directories = [os.path.abspath(d) for d in args.directories]
     os.chdir(args.projdir)
     res_dir = prepare_results(main_script_dir, t_start)
     if args.igndir_clear:
@@ -125,9 +144,13 @@ if __name__ == "__main__":
     loc.ignored_directories_extend(args.igndir)
     loc.ignored_extensions_extend(args.ignext)
     loc.ignored_files_extend(args.ignfiles)
-    stats, fn_map = prepare_for_statistics(args.projdir,
-                                           args.commits_per_step,
-                                           args.count_continued_lines)
+    stats, fn_map = prepare_for_statistics(
+        args.projdir,
+        args.files,
+        args.directories,
+        args.commits_per_step,
+        args.count_continued_lines
+    )
 
     if "all" in args.stats:
         for k in fn_map.keys():


### PR DESCRIPTION
Count lines of codes in files and folders.
If a file or folder argument is specified,
the line count in the project directory will not be counted.

Closses #34